### PR TITLE
support for binary builds when app contains label provider=fabric8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ The goal of this pipeline is to provide a very simple abstraction over top of Je
 2. consuming the data model Jenkins global variable called `dynamicPipeline`, which can retrieve the data model from the SCM repo or via http.
 3. generating Jenkinsfile from the data model and then executing it in the same Groovy shell as the pipeline (know as a `CpsScript` in the Jenkins lingo).
 
+
+## Required Jenkins Variables
+
+This is a list of variables that must be set in Jenkins in order to ensure that the generate script executes as expected. If you are using the seed jobs in the [rht-labs s2i configuration](https://github.com/rht-labs/openshift-jenkins-s2i-config) then these variables will be exposed as require parameters in the seed jobs.
+
+- `$OPENSHIFT_API_TOKEN`: Used to power both the OpenShift Jenkins Pipeline plugin, as well as a few `oc` commands not yet supported in the plugin. This token should align to an OpenShift service account where possible to ensure the configuration doesn't get stale.
+
+
 ## Inspiration
 
 These code bases were instrumental in teaching us how to build a Jenkins plugin and extend the pipeline model:

--- a/src/main/java/com/rhc/dynamic/pipeline/EngagementDAO.java
+++ b/src/main/java/com/rhc/dynamic/pipeline/EngagementDAO.java
@@ -6,28 +6,59 @@ import com.rhc.automation.model.OpenShiftCluster;
 import com.rhc.automation.model.Project;
 import com.rhc.automation.model.Project.EnvironmentTypeEnum;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public final class EngagementDAO {
 
-	public static Project getBuildProject(Engagement engagement) {
+
+	public static Application getApplicationFromBuildProject(Engagement engagement, String applicationName) {
 		for (OpenShiftCluster cluster : engagement.getOpenshiftClusters()) {
 			for (Project project : cluster.getOpenshiftResources().getProjects()) {
 				if (project.getEnvironmentType().equals( EnvironmentTypeEnum.BUILD )) {
-					return project;
+					for (Application app : project.getApps()) {
+						if (app.getName() != null && app.getName().equals( applicationName )) {
+							return app;
+						}
+					}
 				}
 			}
 		}
 		return null;
 	}
 
-	public static Application getApplicationFromBuildProject(Engagement engagement, String applicationName) {
-		Project project = getBuildProject(engagement);
-		for (Application app : project.getApps()) {
-			if (app.getName() != null && app.getName().equals( applicationName )) {
-				return app;
+	public static Project getBuildProjectForApplication( Engagement engagement, String applicationName ) {
+		for (OpenShiftCluster cluster : engagement.getOpenshiftClusters()) {
+			for (Project project : cluster.getOpenshiftResources().getProjects()) {
+				if (project.getEnvironmentType().equals( EnvironmentTypeEnum.BUILD )) {
+					for (Application app : project.getApps()) {
+						if (app.getName() != null && app.getName().equals( applicationName )) {
+							return project;
+						}
+					}
+				}
 			}
 		}
 		return null;
 	}
+
+	public static List<Project> getPromotionProjectsForApplication(Engagement engagement, String applicationName ) {
+		List<Project> projects = new ArrayList<>();
+
+		for (OpenShiftCluster cluster : engagement.getOpenshiftClusters()) {
+			for (Project project : cluster.getOpenshiftResources().getProjects()) {
+				if (project.getEnvironmentType().equals( EnvironmentTypeEnum.PROMOTION )) {
+					for (Application app : project.getApps()) {
+						if (app.getName() != null && app.getName().equals( applicationName )) {
+							projects.add( project );
+						}
+					}
+				}
+			}
+		}
+		return projects;
+	}
+
 
 	/**
 	 * There should only be a single build project declared across all clusters. It is invalid to have more than one.

--- a/src/main/java/com/rhc/dynamic/pipeline/EngagementDAO.java
+++ b/src/main/java/com/rhc/dynamic/pipeline/EngagementDAO.java
@@ -42,4 +42,8 @@ public final class EngagementDAO {
 		}
 		return null;
 	}
+
+	public static OpenShiftCluster getBuildCluster(Engagement engagement){
+		return engagement.getOpenshiftClusters().get(0);
+	}
 }

--- a/src/test/java/com/rhc/dynamic/pipeline/HelpTest.java
+++ b/src/test/java/com/rhc/dynamic/pipeline/HelpTest.java
@@ -1,5 +1,0 @@
-package com.rhc.dynamic.pipeline;
-
-public class HelpTest {
-
-}

--- a/src/test/java/com/rhc/dynamic/pipeline/ReleasePipelineVisitorWithConfigFileTest.java
+++ b/src/test/java/com/rhc/dynamic/pipeline/ReleasePipelineVisitorWithConfigFileTest.java
@@ -123,6 +123,20 @@ public class ReleasePipelineVisitorWithConfigFileTest {
 		Assert.assertEquals(TestUtils.getPipelineScriptFromFileWithoutWhitespace("singleClusterScriptMvn3.groovy"), TestUtils.removeWhiteSpace(argument.getValue()));
 	}
 	
+	@Test
+	public void shouldCorrectlyCreateSingleClusterMultiProjectScriptWithFabric8() throws IOException {
+		// given
+		ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+		DynamicPipelineFactory factory = new DynamicPipelineFactory(mockScript).withConfigurationFile(TestUtils.FABRIC8_BUILD_FILE)
+				.withApplicationName(TestUtils.APPLICATION_NAME);
+
+		// when
+		factory.generateAndExecutePipelineScript();
+
+		// then
+		verify(mockScript).evaluate(argument.capture());
+		Assert.assertEquals(TestUtils.getPipelineScriptFromFileWithoutWhitespace("singleClusterScriptFabric8.groovy"), TestUtils.removeWhiteSpace(argument.getValue()));
+	}
 
 	@Test
 	public void shouldThrowExceptionForUnsupportedBuildTool() throws IOException {

--- a/src/test/java/com/rhc/dynamic/pipeline/ReleasePipelineVisitorWithConfigFileTest.java
+++ b/src/test/java/com/rhc/dynamic/pipeline/ReleasePipelineVisitorWithConfigFileTest.java
@@ -139,6 +139,21 @@ public class ReleasePipelineVisitorWithConfigFileTest {
 	}
 
 	@Test
+	public void shouldCorrectlyCreateAutomationApi() throws IOException {
+		// given
+		ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+		DynamicPipelineFactory factory = new DynamicPipelineFactory(mockScript).withConfigurationFile(TestUtils.LABS_ENV_FILE)
+				.withApplicationName("automation-api");
+
+		// when
+		factory.generateAndExecutePipelineScript();
+
+		// then
+		verify(mockScript).evaluate(argument.capture());
+		Assert.assertEquals(TestUtils.getPipelineScriptFromFileWithoutWhitespace("labs-env.groovy"), TestUtils.removeWhiteSpace(argument.getValue()));
+	}
+
+	@Test
 	public void shouldThrowExceptionForUnsupportedBuildTool() throws IOException {
 		// given
 		DynamicPipelineFactory factory = new DynamicPipelineFactory(mockScript).withConfigurationFile(TestUtils.UNSUPPORTED_BUILD_TOOL_FILE)

--- a/src/test/java/com/rhc/dynamic/pipeline/ReleasePipelineVisitorWithHttpConfigTest.java
+++ b/src/test/java/com/rhc/dynamic/pipeline/ReleasePipelineVisitorWithHttpConfigTest.java
@@ -171,6 +171,21 @@ public class ReleasePipelineVisitorWithHttpConfigTest {
 	}
 
 	@Test
+	public void shouldCorrectlyCreateAutomationApi() throws IOException {
+		// given
+		ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+		DynamicPipelineFactory factory = new DynamicPipelineFactory(mockScript).withHttpConfiguration(TestUtils.getEmbeddedServerUrl(serverPort, TestUtils.LABS_ENV_FILE))
+				.withApplicationName("automation-api");
+
+		// when
+		factory.generateAndExecutePipelineScript();
+
+		// then
+		verify(mockScript).evaluate(argument.capture());
+		Assert.assertEquals(TestUtils.getPipelineScriptFromFileWithoutWhitespace("labs-env.groovy"), TestUtils.removeWhiteSpace(argument.getValue()));
+	}
+
+	@Test
 	public void shouldThrowExceptionForUnsupportedBuildTool() throws IOException {
 		// given
 		DynamicPipelineFactory factory = new DynamicPipelineFactory(mockScript)

--- a/src/test/java/com/rhc/dynamic/pipeline/ReleasePipelineVisitorWithHttpConfigTest.java
+++ b/src/test/java/com/rhc/dynamic/pipeline/ReleasePipelineVisitorWithHttpConfigTest.java
@@ -153,6 +153,22 @@ public class ReleasePipelineVisitorWithHttpConfigTest {
 		Assert.assertEquals(TestUtils.getPipelineScriptFromFileWithoutWhitespace("singleClusterScriptMvn3.groovy"),
 				TestUtils.removeWhiteSpace(argument.getValue()));
 	}
+	
+	@Test
+	public void shouldCorrectlyCreateSingleClusterMultiProjectScriptWithFabric8() throws IOException {
+		// given
+		ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+		DynamicPipelineFactory factory = new DynamicPipelineFactory(mockScript)
+				.withHttpConfiguration(TestUtils.getEmbeddedServerUrl(serverPort, TestUtils.FABRIC8_BUILD_FILE))
+				.withApplicationName(TestUtils.APPLICATION_NAME);
+
+		// when
+		factory.generateAndExecutePipelineScript();
+
+		// then
+		verify(mockScript).evaluate(argument.capture());
+		Assert.assertEquals(TestUtils.getPipelineScriptFromFileWithoutWhitespace("singleClusterScriptFabric8.groovy"), TestUtils.removeWhiteSpace(argument.getValue()));
+	}
 
 	@Test
 	public void shouldThrowExceptionForUnsupportedBuildTool() throws IOException {

--- a/src/test/java/com/rhc/dynamic/pipeline/utils/TestUtils.java
+++ b/src/test/java/com/rhc/dynamic/pipeline/utils/TestUtils.java
@@ -27,6 +27,7 @@ public class TestUtils {
 	public static final String S2I_BUILD_FILE = "com/rhc/dynamic/pipeline/engagements/singleClusterMultiProjectWithS2I.json";
 	public static final String CUSTOM_BUILD_IMAGE_FILE = "com/rhc/dynamic/pipeline/engagements/singleClusterMultiProjectWithCustomBuildImageCommands.json";
 	public static final String MVN_BUILD_FILE = "com/rhc/dynamic/pipeline/engagements/singleClusterMultiProjectWithMvn.json";
+	public static final String FABRIC8_BUILD_FILE = "com/rhc/dynamic/pipeline/engagements/singleClusterMultiProjectWithFabric8.json";
 	public static final String UNSUPPORTED_BUILD_TOOL_FILE = "com/rhc/dynamic/pipeline/engagements/singleClusterMultiProjectWithUnsupportedBuildTool.json";
 	public static final String LABS_ENV_FILE = "com/rhc/dynamic/pipeline/engagements/labsEnv.json";
 

--- a/src/test/java/com/rhc/dynamic/pipeline/utils/TestUtils.java
+++ b/src/test/java/com/rhc/dynamic/pipeline/utils/TestUtils.java
@@ -29,7 +29,7 @@ public class TestUtils {
 	public static final String MVN_BUILD_FILE = "com/rhc/dynamic/pipeline/engagements/singleClusterMultiProjectWithMvn.json";
 	public static final String FABRIC8_BUILD_FILE = "com/rhc/dynamic/pipeline/engagements/singleClusterMultiProjectWithFabric8.json";
 	public static final String UNSUPPORTED_BUILD_TOOL_FILE = "com/rhc/dynamic/pipeline/engagements/singleClusterMultiProjectWithUnsupportedBuildTool.json";
-	public static final String LABS_ENV_FILE = "com/rhc/dynamic/pipeline/engagements/labsEnv.json";
+	public static final String LABS_ENV_FILE = "com/rhc/dynamic/pipeline/engagements/labs-env.json";
 
 	
 	public static String getPipelineScriptFromFileWithoutWhitespace(String fileName) throws IOException {

--- a/src/test/resources/com/rhc/dynamic/pipeline/engagements/labs-env.json
+++ b/src/test/resources/com/rhc/dynamic/pipeline/engagements/labs-env.json
@@ -1,0 +1,133 @@
+{
+  "openshift_clusters": [
+    {
+      "openshift_host_env": "10.1.2.2:8443",
+      "openshift_resources": {
+        "projects": [
+          {
+            "name": "pipeline-dev",
+            "display_name": "Pipeline - Development",
+            "environment_type": "build",
+            "apps": [
+              {
+                "name": "jenkins",
+                "scm_url": "https://github.com/rht-labs/openshift-jenkins-s2i-config.git",
+                "scm_ref": "master",
+                "base_image": "openshift/jenkins",
+                "build_tool": "s2i"
+              }
+            ]
+          },
+          {
+            "name": "pipeline-uat",
+            "display_name": "Pipeline - UAT",
+            "environment_type": "promotion",
+            "apps": [
+              {
+                "name": "jenkins",
+                "base_image": "jenkins"
+              }
+            ]
+          },
+          {
+            "name": "pipeline-delivery",
+            "display_name": "Pipeline - Delivery",
+            "environment_type": "promotion",
+            "apps": [
+              {
+                "name": "jenkins",
+                "base_image": "jenkins"
+              }
+            ]
+          },
+          {
+            "name": "labs-api-dev",
+            "display_name": "Labs API - Development",
+            "environment_type": "build",
+            "apps": [
+              {
+                "name": "automation-api-db",
+                "base_image": "openshift/postgresql",
+                "environment_variables": {
+                  "POSTGRESQL_USER": "foo",
+                  "POSTGRESQL_PASSWORD": "bar",
+                  "POSTGRESQL_DATABASE": "automation_api_dev"
+                }
+              },
+              {
+                "name": "automation-api",
+                "scm_url": "https://github.com/rht-labs/automation-api.git",
+                "scm_ref": "master",
+                "build_tool": "mvn-3",
+                "build_application_commands": [
+                  "mvn clean install"
+                ],
+                "labels": {
+                  "provider": "fabric8"
+                },
+                "environment_variables": {
+                  "POSTGRESQL_USER": "foo",
+                  "POSTGRESQL_PASSWORD": "bar",
+                  "POSTGRESQL_DATABASE": "automation_api_dev",
+                  "POSTGRESQL_SVC": "automation-api-db.labs-api-dev.svc.cluster.local"
+                }
+              }
+            ]
+          },
+          {
+            "name": "labs-api-uat",
+            "display_name": "Labs API - UAT",
+            "environment_type": "promotion",
+            "apps": [
+              {
+                "name": "automation-api-db",
+                "base_image": "openshift/postgresql",
+                "environment_variables": {
+                  "POSTGRESQL_USER": "foo",
+                  "POSTGRESQL_PASSWORD": "bar",
+                  "POSTGRESQL_DATABASE": "automation_api_uat"
+                }
+              },
+              {
+                "name": "automation-api",
+                "base_image": "automation-api",
+                "environment_variables": {
+                  "POSTGRESQL_USER": "foo",
+                  "POSTGRESQL_PASSWORD": "bar",
+                  "POSTGRESQL_DATABASE": "automation_api_uat",
+                  "POSTGRESQL_SVC": "automation-api-db.labs-api-uat.svc.cluster.local"
+                }
+              }
+            ]
+          },
+          {
+            "name": "labs-api-delivery",
+            "display_name": "Labs API - Delivery",
+            "environment_type": "promotion",
+            "apps": [
+              {
+                "name": "automation-api",
+                "base_image": "automation-api",
+                "environment_variables": {
+                  "POSTGRESQL_USER": "foo",
+                  "POSTGRESQL_PASSWORD": "bar",
+                  "POSTGRESQL_DATABASE": "automation_api_delivery",
+                  "POSTGRESQL_SVC": "automation-api-db.labs-api-delivery.svc.cluster.local"
+                }
+              },
+              {
+                "name": "automation-api-db",
+                "base_image": "openshift/postgresql",
+                "environment_variables": {
+                  "POSTGRESQL_USER": "foo",
+                  "POSTGRESQL_PASSWORD": "bar",
+                  "POSTGRESQL_DATABASE": "automation_api_delivery"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/com/rhc/dynamic/pipeline/engagements/singleClusterMultiProjectWithFabric8.json
+++ b/src/test/resources/com/rhc/dynamic/pipeline/engagements/singleClusterMultiProjectWithFabric8.json
@@ -1,0 +1,67 @@
+{
+	"openshift_clusters": [
+		{
+			"id": 1,
+			"labels": {
+				
+			},
+			"openshift_resources": {
+				"projects": [
+					{
+						"name": "dev-project",
+						"environment_type": "build",
+						"apps": [
+							{
+								"build_application_commands": ["mvn clean deploy"],
+								"build_image_commands": [],
+								"deploy_image_commands": [],
+								"context_dir": "",
+								"build_tool": "mvn-3",
+								"scm_url": "https://foo.bar.com/justin.git",
+								"name": "cool-application-name",
+								"labels": {
+									"provider": "fabric8"
+								},
+								"environment_variables": {
+									
+								}
+							}
+						],
+						"user_to_role": []
+					},
+					{
+						"name": "stage-project",
+						"environment_type": "promotion",
+						"apps": [
+							{
+								"name": "cool-application-name"
+							}
+						],
+						"user_to_role": []
+					},
+					{
+						"name": "prod-project",
+						"environment_type": "promotion",
+						"apps": [
+							{
+								"build_application_commands": [],
+								"build_image_commands": [],
+								"deploy_image_commands": [],
+								"name": "cool-application-name",
+								"labels": {
+									
+								},
+								"environment_variables": {
+									
+								}
+							}
+						],
+						"user_to_role": []
+					}
+				]
+			},
+			"openshift_host_env": "10.1.2.2:8443"
+		}
+	],
+	"team": []
+}

--- a/src/test/resources/com/rhc/dynamic/pipeline/scripts/labs-env.groovy
+++ b/src/test/resources/com/rhc/dynamic/pipeline/scripts/labs-env.groovy
@@ -1,0 +1,30 @@
+node {
+    stage ('Code Checkout') {
+        git url: 'https://github.com/rht-labs/automation-api.git', branch: 'master'
+    }
+
+    stage ('Build App') {
+        echo 'Using build tool: mvn-3'
+        def toolHome = tool 'mvn-3'
+        env.JAVA_HOME = tool 'java-1.8'
+        sh "${toolHome}/bin/mvn clean install"
+    }
+
+
+    stage ('Build Image and Deploy to Dev') {
+        echo 'Found label "provider=fabric8", we are generating the s2i binary build commands'
+        sh 'oc login 10.1.2.2:8443 --token=$OPENSHIFT_API_TOKEN --insecure-skip-tls-verify'
+        sh 'oc start-build automation-api --from-dir=. --follow -n labs-api-dev'  }
+
+    stage ('Deploy to labs-api-uat') {
+        input 'Deploy to labs-api-uat?'
+        openshiftTag apiURL: '10.1.2.2:8443', authToken: $OPENSHIFT_API_TOKEN, destStream: 'automation-api', destTag: 'latest', destinationAuthToken: $OPENSHIFT_API_TOKEN, destinationNamespace: 'labs-api-uat', namespace: 'labs-api-dev', srcStream: 'automation-api', srcTag: 'latest'
+        openshiftVerifyDeployment apiURL: '10.1.2.2:8443', authToken: $OPENSHIFT_API_TOKEN, depCfg: 'automation-api', namespace: 'labs-api-uat'
+    }
+
+    stage ('Deploy to labs-api-delivery') {
+        input 'Deploy to labs-api-delivery?'
+        openshiftTag apiURL: '10.1.2.2:8443', authToken: $OPENSHIFT_API_TOKEN, destStream: 'automation-api', destTag: 'latest', destinationAuthToken: $OPENSHIFT_API_TOKEN, destinationNamespace: 'labs-api-delivery', namespace: 'labs-api-uat', srcStream: 'automation-api', srcTag: 'latest'
+        openshiftVerifyDeployment apiURL: '10.1.2.2:8443', authToken: $OPENSHIFT_API_TOKEN, depCfg: 'automation-api', namespace: 'labs-api-delivery'
+    }
+}

--- a/src/test/resources/com/rhc/dynamic/pipeline/scripts/singleClusterScriptFabric8.groovy
+++ b/src/test/resources/com/rhc/dynamic/pipeline/scripts/singleClusterScriptFabric8.groovy
@@ -1,0 +1,30 @@
+node {
+	stage ('Code Checkout'){ 
+	    git url: 'https://foo.bar.com/justin.git', branch: 'master' 
+	}
+
+	stage ('Build App'){
+		echo 'Using build tool: mvn-3'
+		def toolHome = tool 'mvn-3'
+		env.JAVA_HOME = tool 'java-1.8'
+		sh "${toolHome}/bin/mvn clean deploy"
+	}
+
+	stage ('Build Image and Deploy to Dev'){
+		echo 'Found label "provider=fabric8", we're generating the s2i binary build commands'
+		sh 'oc login 10.1.2.2:8443 --token=$OPENSHIFT_API_TOKEN --insecure-skip-tls-verify'
+		sh 'oc start-build cool-application-name --from-dir=. --follow -n dev-project'
+	}
+
+	stage ('Deploy to stage-project') {
+		input 'Deploy to stage-project?'
+		openshiftTag apiURL: '10.1.2.2:8443', authToken: $OPENSHIFT_API_TOKEN, destStream: 'cool-application-name', destTag: 'latest', destinationAuthToken: $OPENSHIFT_API_TOKEN, destinationNamespace: 'stage-project', namespace: 'dev-project', srcStream: 'cool-application-name', srcTag: 'latest'
+		openshiftVerifyDeployment apiURL: '10.1.2.2:8443', authToken: $OPENSHIFT_API_TOKEN, depCfg: 'cool-application-name', namespace: 'stage-project'
+	}
+
+	stage ('Deploy to prod-project') {
+		input 'Deploy to prod-project?'
+		openshiftTag apiURL: '10.1.2.2:8443', authToken: $OPENSHIFT_API_TOKEN, destStream: 'cool-application-name', destTag: 'latest', destinationAuthToken: $OPENSHIFT_API_TOKEN, destinationNamespace: 'prod-project', namespace: 'stage-project', srcStream: 'cool-application-name', srcTag: 'latest'
+		openshiftVerifyDeployment apiURL: '10.1.2.2:8443', authToken: $OPENSHIFT_API_TOKEN, depCfg: 'cool-application-name', namespace: 'prod-project'
+	}
+}

--- a/src/test/resources/com/rhc/dynamic/pipeline/scripts/singleClusterScriptFabric8.groovy
+++ b/src/test/resources/com/rhc/dynamic/pipeline/scripts/singleClusterScriptFabric8.groovy
@@ -11,7 +11,7 @@ node {
 	}
 
 	stage ('Build Image and Deploy to Dev'){
-		echo 'Found label "provider=fabric8", we're generating the s2i binary build commands'
+		echo 'Found label "provider=fabric8", we are generating the s2i binary build commands'
 		sh 'oc login 10.1.2.2:8443 --token=$OPENSHIFT_API_TOKEN --insecure-skip-tls-verify'
 		sh 'oc start-build cool-application-name --from-dir=. --follow -n dev-project'
 	}


### PR DESCRIPTION
#### What does this PR do?
Dynamically generate the openshift s2i binary builds required by fabric8 in order to avoid putting cluster details like hostname in custom build image commands. Requested by @oybed 

#### Which tests illustrate how this code works?
See unit tests that end in fabric8

#### Is there a relevant Issue open for this?
resolves #7 
resolves #10 

#### Are there any other relevant resources that should be reviewed as well?
Nope

#### Who would you like to review this?
/cc @mdanter @oybed 

